### PR TITLE
Fix #4: expand multi-source OSINT ingestion

### DIFF
--- a/backend/app/ingestion/config.py
+++ b/backend/app/ingestion/config.py
@@ -24,4 +24,24 @@ DEFAULT_RSS_FEEDS: List[RSSFeedConfig] = [
         name="UN News",
         url="https://news.un.org/feed/subscribe/en/news/all/rss.xml",
     ),
+    RSSFeedConfig(
+        name="Defense News",
+        url="https://www.defensenews.com/arc/outboundfeeds/rss/",
+    ),
+    RSSFeedConfig(
+        name="Reuters World",
+        url="https://www.reutersagency.com/feed/?best-topics=world-news",
+    ),
+    RSSFeedConfig(
+        name="ReliefWeb Crisis Reports",
+        url="https://reliefweb.int/updates/rss.xml",
+    ),
+    RSSFeedConfig(
+        name="US Naval Institute News",
+        url="https://news.usni.org/feed",
+    ),
+    RSSFeedConfig(
+        name="UK MOD / Security Announcements",
+        url="https://www.gov.uk/government/organisations/ministry-of-defence.atom",
+    ),
 ]

--- a/backend/app/intelligence/config.py
+++ b/backend/app/intelligence/config.py
@@ -44,6 +44,11 @@ SOURCE_RELIABILITY_MAP: Dict[str, float] = {
     "al jazeera": 85.0,
     "un news": 85.0,
     "telegram": 50.0,
+    "defense news": 85.0,
+    "reuters world": 90.0,
+    "reliefweb crisis reports": 90.0,
+    "us naval institute news": 85.0,
+    "uk mod / security announcements": 90.0,
 }
 DEFAULT_SOURCE_RELIABILITY: float = 60.0
 

--- a/backend/tests/test_intelligence.py
+++ b/backend/tests/test_intelligence.py
@@ -10,6 +10,8 @@ from app.intelligence.clustering import (
     find_best_matching_event,
     haversine_distance_km,
 )
+from app.ingestion.config import DEFAULT_RSS_FEEDS
+from app.intelligence.config import SOURCE_RELIABILITY_MAP, DEFAULT_SOURCE_RELIABILITY
 
 # ==========================================
 # 1. THREAT SCORING TESTS
@@ -124,6 +126,39 @@ def test_credibility_reliable_vs_low_reliability():
     score_low, _ = calculate_credibility_score(["telegram"])
     assert score_rel > score_low
     assert score_low == 50.0  # Base for telegram
+
+def test_credibility_new_defense_sources():
+    sources = [
+        "defense news",
+        "reuters world",
+        "reliefweb crisis reports",
+        "us naval institute news",
+        "uk mod / security announcements"
+    ]
+    for source in sources:
+        score, _ = calculate_credibility_score([source])
+        assert score == SOURCE_RELIABILITY_MAP[source]
+        assert score != DEFAULT_SOURCE_RELIABILITY
+
+def test_feed_registry_sources_exist():
+    expected_feeds = [
+        "Defense News",
+        "Reuters World",
+        "ReliefWeb Crisis Reports",
+        "US Naval Institute News",
+        "UK MOD / Security Announcements"
+    ]
+    feed_names = [feed.name for feed in DEFAULT_RSS_FEEDS]
+    
+    for expected in expected_feeds:
+        assert expected in feed_names
+        
+        feed_config = next(f for f in DEFAULT_RSS_FEEDS if f.name == expected)
+        assert feed_config.url.strip() != ""
+        
+        mapped_key = expected.lower()
+        assert mapped_key in SOURCE_RELIABILITY_MAP
+        assert SOURCE_RELIABILITY_MAP[mapped_key] != DEFAULT_SOURCE_RELIABILITY
 
 
 # ==========================================


### PR DESCRIPTION
## Summary

Implements #4 by expanding ThreatAtlas OSINT ingestion with specialized defense, geopolitical, and crisis-monitoring public feeds.

### Changes

- Added Defense News RSS feed.
- Added Reuters World feed.
- Added ReliefWeb Crisis Reports RSS feed.
- Added US Naval Institute News RSS feed.
- Added UK MOD / Security Announcements Atom feed.
- Added curated source reliability scores:
  - Defense News: 85.0
  - Reuters World: 90.0
  - ReliefWeb Crisis Reports: 90.0
  - US Naval Institute News: 85.0
  - UK MOD / Security Announcements: 90.0
- Added tests validating the new feed registry and reliability mappings.

## Validation

- Backend: 54 tests passed.
- Frontend production build passed.
- All five feed endpoints were checked before implementation.
- RSS and Atom feed handling remains compatible with the existing ingestion pipeline.
- Existing multipart deprecation warning remains with no test failures.

Fixes #4