### PR TITLE
Feat #13: add country-level event filtering

### DIFF
--- a/backend/app/api/v1/endpoints/events.py
+++ b/backend/app/api/v1/endpoints/events.py
@@ -45,6 +45,7 @@ async def list_events(
     end_date: Optional[datetime] = Query(default=None, description="End date (UTC ISO)"),
     bbox: Optional[str] = Query(default=None, description="Geospatial bounding box 'min_lon,min_lat,max_lon,max_lat'"),
     search: Optional[str] = Query(default=None, description="Text search in title or summary"),
+    countries: Optional[str] = Query(default=None, description="Comma-separated ISO country codes (e.g. ua,ru)"),
 ):
     """Retrieve intelligence events with rich filtering, text search, geospatial bounding box, and pagination."""
     if threat_level and threat_level not in {"Low", "Medium", "High"}:
@@ -54,6 +55,13 @@ async def list_events(
         )
 
     parsed_bbox = parse_and_validate_bbox(bbox)
+
+    parsed_countries = None
+    if countries:
+        parsed_countries = list({c.strip().lower() for c in countries.split(",") if c.strip()})
+        if not parsed_countries:
+            parsed_countries = None
+
     db = get_database()
     event_repo = EventRepository(db)
 
@@ -67,6 +75,7 @@ async def list_events(
         end_date=end_date,
         bbox=parsed_bbox,
         search=search,
+        countries=parsed_countries,
     )
     total = await event_repo.count_events(
         threat_level=threat_level,
@@ -76,6 +85,7 @@ async def list_events(
         end_date=end_date,
         bbox=parsed_bbox,
         search=search,
+        countries=parsed_countries,
     )
 
     return EventListResponse(total=total, limit=limit, skip=skip, items=events)
@@ -87,6 +97,14 @@ async def get_global_metrics():
     db = get_database()
     event_repo = EventRepository(db)
     return await event_repo.get_global_metrics()
+
+
+@router.get("/countries", response_model=List[str], summary="Get Available Countries")
+async def get_countries():
+    """Retrieve list of distinct country codes present in events."""
+    db = get_database()
+    event_repo = EventRepository(db)
+    return await event_repo.get_distinct_countries()
 
 
 @router.get("/{id}", response_model=EventResponse, summary="Get Single Intelligence Event")

--- a/backend/app/db/repositories/event.py
+++ b/backend/app/db/repositories/event.py
@@ -59,6 +59,7 @@ class EventRepository:
         end_date: Optional[datetime] = None,
         bbox: Optional[List[float]] = None,
         search: Optional[str] = None,
+        countries: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Construct MongoDB filter query from parameters."""
         query: Dict[str, Any] = {}
@@ -98,6 +99,9 @@ class EventRepository:
                 {"summary": {"$regex": search, "$options": "i"}},
             ]
 
+        if countries:
+            query["country_code"] = {"$in": countries}
+
         return query
 
     async def list_events(
@@ -111,6 +115,7 @@ class EventRepository:
         end_date: Optional[datetime] = None,
         bbox: Optional[List[float]] = None,
         search: Optional[str] = None,
+        countries: Optional[List[str]] = None,
     ) -> List[EventResponse]:
         """List events with rich filtering and pagination."""
         query = self._build_query(
@@ -121,6 +126,7 @@ class EventRepository:
             end_date=end_date,
             bbox=bbox,
             search=search,
+            countries=countries,
         )
 
         cursor = (
@@ -141,8 +147,9 @@ class EventRepository:
         end_date: Optional[datetime] = None,
         bbox: Optional[List[float]] = None,
         search: Optional[str] = None,
+        countries: Optional[List[str]] = None,
     ) -> int:
-        """Count total matching events for a query."""
+        """Count total documents matching filters for pagination."""
         query = self._build_query(
             threat_level=threat_level,
             min_threat_score=min_threat_score,
@@ -151,6 +158,7 @@ class EventRepository:
             end_date=end_date,
             bbox=bbox,
             search=search,
+            countries=countries,
         )
         return await self.collection.count_documents(query)
 
@@ -195,8 +203,13 @@ class EventRepository:
             low=low
         )
 
+    async def get_distinct_countries(self) -> List[str]:
+        """Get distinct country codes that exist in current events, omitting null/empty."""
+        countries = await self.collection.distinct("country_code")
+        return sorted([c for c in countries if c and isinstance(c, str) and c.strip()])
+
     @staticmethod
-    def _to_response(doc: dict) -> EventResponse:
+    def _to_response(doc: Dict[str, Any]) -> EventResponse:
         """Convert MongoDB document dict to EventResponse Pydantic model."""
         doc_copy = dict(doc)
         doc_copy["id"] = str(doc_copy.pop("_id"))

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -86,6 +86,10 @@ async def init_db() -> None:
             [("location", GEOSPHERE)],
             name="idx_events_location_2dsphere",
         ),
+        IndexModel(
+            [("country_code", ASCENDING)],
+            name="idx_events_country_code",
+        ),
     ]
 
     try:

--- a/backend/app/intelligence/service.py
+++ b/backend/app/intelligence/service.py
@@ -112,9 +112,11 @@ class IntelligenceService:
             # Construct Event Location
             location_name = None
             geo_location = None
+            country_code = None
             if nlp_result.locations:
                 primary_loc = nlp_result.locations[0]
                 location_name = primary_loc.name
+                country_code = primary_loc.country_code
                 if primary_loc.lat != 0.0 or primary_loc.lng != 0.0:
                     # GeoJSON is [lng, lat]
                     geo_location = GeoJSONPoint(coordinates=[primary_loc.lng, primary_loc.lat])
@@ -151,6 +153,7 @@ class IntelligenceService:
                 entities=entities_dict,
                 location_name=location_name,
                 location=geo_location,
+                country_code=country_code,
                 event_timestamp=raw_post.original_timestamp,
                 threat_score=threat_score,
                 threat_level=threat_level,

--- a/backend/app/nlp/geocoder.py
+++ b/backend/app/nlp/geocoder.py
@@ -5,17 +5,17 @@ from app.db.session import get_database
 USER_AGENT = "ThreatAtlas/1.0 (Student Project)"
 NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
 
-async def geocode(location_name: str) -> Optional[Tuple[float, float]]:
+async def geocode(location_name: str) -> Optional[Tuple[float, float, Optional[str]]]:
     """
-    Geocodes a location name to (lat, lng).
+    Geocodes a location name to (lat, lng, country_code).
     Uses a local MongoDB cache to avoid Nominatim rate limits.
-    Returns (lat, lng) or None if not found.
+    Returns (lat, lng, country_code) or None if not found.
     """
     if not location_name:
         return None
-        
+
     normalized_name = location_name.strip().lower()
-    
+
     # 1. Check Cache
     db = get_database()
     cache = db.geocache
@@ -23,31 +23,37 @@ async def geocode(location_name: str) -> Optional[Tuple[float, float]]:
     if cached:
         if cached.get("not_found"):
             return None
-        return (cached["lat"], cached["lng"])
-        
+        return (cached["lat"], cached["lng"], cached.get("country_code"))
+
     # 2. Query Nominatim
     async with httpx.AsyncClient() as client:
         try:
             response = await client.get(
                 NOMINATIM_URL,
-                params={"q": location_name, "format": "json", "limit": 1},
+                params={"q": location_name, "format": "json", "limit": 1, "addressdetails": 1},
                 headers={"User-Agent": USER_AGENT},
                 timeout=5.0
             )
             response.raise_for_status()
             data = response.json()
-            
+
             if data and len(data) > 0:
                 lat = float(data[0]["lat"])
                 lng = float(data[0]["lon"])
+
+                # Extract country code
+                country_code = data[0].get("address", {}).get("country_code")
+                if country_code:
+                    country_code = country_code.lower()
+
                 # Save to cache
-                await cache.insert_one({"name": normalized_name, "lat": lat, "lng": lng})
-                return (lat, lng)
+                await cache.insert_one({"name": normalized_name, "lat": lat, "lng": lng, "country_code": country_code})
+                return (lat, lng, country_code)
             else:
                 # Cache miss
                 await cache.insert_one({"name": normalized_name, "not_found": True})
                 return None
-                
+
         except Exception as e:
             # On error, fail gracefully and don't cache
             print(f"Geocoding error for '{location_name}': {e}")

--- a/backend/app/nlp/schemas.py
+++ b/backend/app/nlp/schemas.py
@@ -12,6 +12,7 @@ class Location(BaseModel):
     lat: float
     lng: float
     confidence: str = Field(default="unknown", description="e.g., high, medium, low, unknown")
+    country_code: Optional[str] = None
 
 class NLPResult(BaseModel):
     original_text: str

--- a/backend/app/nlp/service.py
+++ b/backend/app/nlp/service.py
@@ -61,7 +61,8 @@ class NLPService:
                             name=loc_text,
                             lat=geo_res[0],
                             lng=geo_res[1],
-                            confidence="high" # Simple heuristic for MVP
+                            confidence="high", # Simple heuristic for MVP
+                            country_code=geo_res[2] if len(geo_res) > 2 else None
                         ))
                     else:
                         locations.append(Location(

--- a/backend/app/schemas/event.py
+++ b/backend/app/schemas/event.py
@@ -18,6 +18,7 @@ class EventBase(BaseModel):
     entities: Dict[str, List[str]] = Field(default_factory=default_entities, description="Extracted named entities")
     location_name: Optional[str] = Field(None, description="Human-readable location name")
     location: Optional[GeoJSONPoint] = Field(None, description="GeoJSON point coordinates [lng, lat]")
+    country_code: Optional[str] = Field(None, description="ISO 3166-1 alpha-2 country code")
     event_timestamp: datetime = Field(..., description="Primary timestamp when the event occurred (UTC)")
     threat_score: float = Field(default=0.0, ge=0.0, le=100.0, description="Calculated threat score (0-100)")
     threat_level: str = Field(default="Low", description="Threat category: Low, Medium, High")
@@ -55,6 +56,7 @@ class EventUpdate(BaseModel):
     entities: Optional[Dict[str, List[str]]] = None
     location_name: Optional[str] = None
     location: Optional[GeoJSONPoint] = None
+    country_code: Optional[str] = None
     event_timestamp: Optional[datetime] = None
     threat_score: Optional[float] = Field(None, ge=0.0, le=100.0)
     threat_level: Optional[str] = None

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -190,7 +190,7 @@ def test_process_pending_irrelevant_post(mocker):
     mock_nlp_result = MagicMock()
     mocker.patch("app.api.v1.endpoints.intelligence.nlp_service.process_text", AsyncMock(return_value=mock_nlp_result))
     mocker.patch("app.api.v1.endpoints.intelligence.is_post_relevant", return_value=False)
-    
+
     mock_process_post = mocker.patch(
         "app.api.v1.endpoints.intelligence.intelligence_service.process_post",
         AsyncMock()
@@ -204,7 +204,7 @@ def test_process_pending_irrelevant_post(mocker):
     assert data["events_merged"] == 0
     assert data["events_ignored"] == 1
     assert data["errors"] == 0
-    
+
     mock_update.assert_called_with(post_id, "ignored")
     mock_process_post.assert_not_called()
 
@@ -234,3 +234,24 @@ def test_get_global_metrics_endpoint(mocker):
     assert data["high"] == 20
     assert data["medium"] == 50
     assert data["low"] == 80
+
+def test_events_country_filtering_and_endpoint(mocker):
+    # Test valid countries param
+    mock_list = mocker.patch("app.api.v1.endpoints.events.EventRepository.list_events", return_value=[])
+    mock_count = mocker.patch("app.api.v1.endpoints.events.EventRepository.count_events", return_value=0)
+    mocker.patch("app.api.v1.endpoints.events.get_database", return_value=mocker.MagicMock())
+
+    response = client.get("/api/v1/events?countries= ua, ru ,")
+    assert response.status_code == 200
+
+    # Assert parsed correctly to lowercase array
+    mock_list.assert_called_once()
+    kwargs = mock_list.call_args.kwargs
+    # Because sets can be unordered, we sort them for the check or just compare sets
+    assert set(kwargs["countries"]) == {"ua", "ru"}
+
+    # Test the countries endpoint
+    mock_distinct = mocker.patch("app.api.v1.endpoints.events.EventRepository.get_distinct_countries", return_value=["fr", "ua"])
+    response2 = client.get("/api/v1/events/countries")
+    assert response2.status_code == 200
+    assert response2.json() == ["fr", "ua"]

--- a/backend/tests/test_geocoder.py
+++ b/backend/tests/test_geocoder.py
@@ -1,0 +1,73 @@
+import pytest
+from app.nlp.geocoder import geocode
+
+@pytest.mark.asyncio
+async def test_geocode_success_with_country(mocker):
+    # Mock httpx.AsyncClient.get
+    mock_response = mocker.Mock()
+    mock_response.raise_for_status = mocker.Mock()
+    mock_response.json.return_value = [
+        {
+            "lat": "48.8566",
+            "lon": "2.3522",
+            "address": {
+                "country_code": "FR"
+            }
+        }
+    ]
+
+    mock_client_instance = mocker.Mock()
+    mock_client_instance.get = mocker.AsyncMock(return_value=mock_response)
+
+    # httpx.AsyncClient is an async context manager
+    mock_client_instance.__aenter__ = mocker.AsyncMock(return_value=mock_client_instance)
+    mock_client_instance.__aexit__ = mocker.AsyncMock(return_value=None)
+
+    mocker.patch("httpx.AsyncClient", return_value=mock_client_instance)
+
+    # Mock DB cache miss
+    mock_db = mocker.patch("app.nlp.geocoder.get_database")
+    mock_cache = mocker.Mock()
+    mock_cache.find_one = mocker.AsyncMock(return_value=None)
+    mock_cache.insert_one = mocker.AsyncMock()
+    mock_db.return_value.geocache = mock_cache
+
+    res = await geocode("Paris")
+    assert res is not None
+    lat, lng, cc = res
+    assert lat == 48.8566
+    assert lng == 2.3522
+    assert cc == "fr"  # lowercased
+
+@pytest.mark.asyncio
+async def test_geocode_success_without_country(mocker):
+    # Mock httpx.AsyncClient.get
+    mock_response = mocker.Mock()
+    mock_response.raise_for_status = mocker.Mock()
+    mock_response.json.return_value = [
+        {
+            "lat": "48.8566",
+            "lon": "2.3522"
+        }
+    ]
+
+    mock_client_instance = mocker.Mock()
+    mock_client_instance.get = mocker.AsyncMock(return_value=mock_response)
+    mock_client_instance.__aenter__ = mocker.AsyncMock(return_value=mock_client_instance)
+    mock_client_instance.__aexit__ = mocker.AsyncMock(return_value=None)
+
+    mocker.patch("httpx.AsyncClient", return_value=mock_client_instance)
+
+    # Mock DB cache miss
+    mock_db = mocker.patch("app.nlp.geocoder.get_database")
+    mock_cache = mocker.Mock()
+    mock_cache.find_one = mocker.AsyncMock(return_value=None)
+    mock_cache.insert_one = mocker.AsyncMock()
+    mock_db.return_value.geocache = mock_cache
+
+    res = await geocode("Somewhere")
+    assert res is not None
+    lat, lng, cc = res
+    assert lat == 48.8566
+    assert lng == 2.3522
+    assert cc is None

--- a/backend/tests/test_nlp.py
+++ b/backend/tests/test_nlp.py
@@ -10,14 +10,14 @@ def test_clean_text():
 @pytest.mark.asyncio
 async def test_process_text(mocker):
     # Mock geocoder to prevent actual HTTP requests during tests
-    mocker.patch("app.nlp.service.geocode", return_value=(48.8566, 2.3522))
+    mocker.patch("app.nlp.service.geocode", return_value=(48.8566, 2.3522, "fr"))
     
     text = "Reports of an explosion near Paris today. Several T-72 tanks were seen."
     result = await nlp_service.process_text(text)
     
     # We expect 'Paris' to be in locations due to 'GPE' extraction
     assert any(loc.name.lower() == "paris" for loc in result.locations)
-    assert any(loc.lat == 48.8566 and loc.lng == 2.3522 for loc in result.locations)
+    assert any(loc.lat == 48.8566 and loc.lng == 2.3522 and loc.country_code == "fr" for loc in result.locations)
     
     # We expect 'explosion' to be in event_types
     assert "explosion" in result.event_types

--- a/backend/tests/test_repository.py
+++ b/backend/tests/test_repository.py
@@ -108,3 +108,20 @@ async def test_event_repository_get_global_metrics():
     assert metrics.total == 65
 
     mock_collection.aggregate.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_event_repository_build_query_countries():
+    repo = EventRepository(AsyncMock())
+
+    # Test valid countries
+    query = repo._build_query(countries=["ua", "ru"])
+    assert "country_code" in query
+    assert query["country_code"] == {"$in": ["ua", "ru"]}
+
+    # Test empty countries
+    query_empty = repo._build_query(countries=[])
+    assert "country_code" not in query_empty
+
+    # Test None countries
+    query_none = repo._build_query(countries=None)
+    assert "country_code" not in query_none

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -90,3 +90,15 @@ def test_geojson_point_validation():
 
     with pytest.raises(ValidationError):
         GeoJSONPoint(coordinates=[30.5234])  # Invalid, requires 2 floats
+
+def test_event_schema_country_code():
+    from app.schemas.event import EventBase
+    from datetime import datetime
+
+    # Valid with country code
+    evt1 = EventBase(title="Test", event_timestamp=datetime.now(), country_code="ua")
+    assert evt1.country_code == "ua"
+
+    # Valid without country code
+    evt2 = EventBase(title="Test", event_timestamp=datetime.now())
+    assert evt2.country_code is None

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -25,6 +25,9 @@ export const fetchEvents = async (filters: EventFilters = {}): Promise<EventList
   if (filters.search) params.search = filters.search;
   if (filters.event_type) params.event_type = filters.event_type;
   if (filters.bbox) params.bbox = filters.bbox;
+  if (filters.countries && filters.countries.length > 0) {
+    params.countries = filters.countries.join(',');
+  }
 
   const response = await apiClient.get<EventListResponse>('/events', { params });
   return response.data;
@@ -32,6 +35,11 @@ export const fetchEvents = async (filters: EventFilters = {}): Promise<EventList
 
 export const fetchGlobalMetrics = async (): Promise<EventGlobalMetrics> => {
   const response = await apiClient.get<EventGlobalMetrics>('/events/stats');
+  return response.data;
+};
+
+export const fetchAvailableCountries = async (): Promise<string[]> => {
+  const response = await apiClient.get<string[]>('/events/countries');
   return response.data;
 };
 

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import { Search, AlertTriangle, ShieldAlert, ShieldCheck, MapPin, Calendar } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+import { Search, AlertTriangle, ShieldAlert, ShieldCheck, MapPin, Calendar, Globe, X, ChevronDown } from 'lucide-react';
 import type { Event, EventFilters, EventGlobalMetrics } from '../types';
+import { fetchAvailableCountries } from '../api/client';
 
 interface FilterPanelProps {
   filters: EventFilters;
@@ -19,6 +20,34 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
   onSelectEvent,
   globalMetrics,
 }) => {
+  const [availableCountries, setAvailableCountries] = useState<string[]>([]);
+  const [isLoadingCountries, setIsLoadingCountries] = useState(false);
+  const [isCountryDropdownOpen, setIsCountryDropdownOpen] = useState(false);
+
+  useEffect(() => {
+    const loadCountries = async () => {
+      setIsLoadingCountries(true);
+      try {
+        const countries = await fetchAvailableCountries();
+        setAvailableCountries(countries);
+      } catch (err) {
+        console.error('Failed to load available countries', err);
+      } finally {
+        setIsLoadingCountries(false);
+      }
+    };
+    loadCountries();
+  }, []);
+
+  const getCountryName = (code: string) => {
+    try {
+      const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
+      return regionNames.of(code.toUpperCase()) || code.toUpperCase();
+    } catch {
+      return code.toUpperCase();
+    }
+  };
+
   const highCount = globalMetrics.high;
   const medCount = globalMetrics.medium;
   const lowCount = globalMetrics.low;
@@ -39,6 +68,20 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
   const handleToggleHideLowThreat = () => {
     const isHidden = filters.min_threat_score === 40;
     onFilterChange({ ...filters, min_threat_score: isHidden ? undefined : 40 });
+  };
+
+  const handleCountryToggle = (code: string) => {
+    const current = filters.countries || [];
+    const updated = current.includes(code)
+      ? current.filter(c => c !== code)
+      : [...current, code];
+
+    onFilterChange({ ...filters, countries: updated });
+  };
+
+  const handleClearCountries = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onFilterChange({ ...filters, countries: [] });
   };
 
   return (
@@ -129,6 +172,59 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
             aria-label="Minimum Threat Score"
             className="w-full accent-blue-500 h-1.5 bg-slate-800 rounded-lg appearance-none cursor-pointer"
           />
+        </div>
+
+        {/* Country Filter */}
+        <div className="pt-2 space-y-2 relative">
+          <div className="flex items-center justify-between text-xs font-mono text-slate-300">
+            <label className="font-semibold flex items-center gap-1">
+              <Globe className="w-3.5 h-3.5 text-slate-400" /> Countries
+            </label>
+            {(filters.countries?.length || 0) > 0 && (
+              <button
+                onClick={handleClearCountries}
+                className="text-[10px] bg-slate-800 hover:bg-slate-700 text-slate-300 px-1.5 py-0.5 rounded transition-colors flex items-center gap-0.5"
+              >
+                <X className="w-3 h-3" /> Clear
+              </button>
+            )}
+          </div>
+
+          <button
+            onClick={() => setIsCountryDropdownOpen(!isCountryDropdownOpen)}
+            className="w-full flex items-center justify-between px-3 py-2 bg-slate-900 border border-slate-800 hover:border-slate-700 rounded-lg text-xs text-slate-300 transition-colors font-mono"
+          >
+            <span className="truncate">
+              {isLoadingCountries ? 'Loading...' :
+                (filters.countries?.length || 0) > 0
+                  ? `${filters.countries!.length} selected`
+                  : 'All Countries'}
+            </span>
+            <ChevronDown className={`w-4 h-4 text-slate-500 transition-transform ${isCountryDropdownOpen ? 'rotate-180' : ''}`} />
+          </button>
+
+          {isCountryDropdownOpen && (
+            <div className="absolute top-full left-0 right-0 mt-1 max-h-48 overflow-y-auto bg-slate-900 border border-slate-700 rounded-lg shadow-xl z-50 p-1 font-mono text-xs scrollbar-thin scrollbar-thumb-slate-700 scrollbar-track-transparent">
+              {availableCountries.length === 0 && !isLoadingCountries ? (
+                <div className="p-2 text-slate-500 text-center">No countries available</div>
+              ) : (
+                availableCountries.map(code => (
+                  <label key={code} className="flex items-center gap-2 p-2 hover:bg-slate-800 rounded cursor-pointer transition-colors group">
+                    <input
+                      type="checkbox"
+                      checked={(filters.countries || []).includes(code)}
+                      onChange={() => handleCountryToggle(code)}
+                      className="w-3.5 h-3.5 rounded border-slate-700 text-blue-500 bg-slate-950 focus:ring-blue-500/20 focus:ring-offset-slate-900"
+                    />
+                    <span className="text-slate-300 group-hover:text-slate-100 flex-1 truncate">
+                      {getCountryName(code)}
+                    </span>
+                    <span className="text-slate-600 uppercase text-[9px]">{code}</span>
+                  </label>
+                ))
+              )}
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -40,6 +40,7 @@ export interface Event {
   entities: EventEntities;
   location_name?: string;
   location?: GeoJSONPoint;
+  country_code?: string;
   event_timestamp: string;
   threat_score: number;
   threat_level: 'Low' | 'Medium' | 'High';
@@ -100,4 +101,5 @@ export interface EventFilters {
   search?: string;
   event_type?: string;
   bbox?: string;
+  countries?: string[];
 }


### PR DESCRIPTION
## Summary

- Add ISO country-code extraction during Nominatim geocoding.
- Persist country codes on events for country-aware filtering.
- Add backend country filtering using MongoDB `$in` queries.
- Add an endpoint for available countries present in the event dataset.
- Add a country selector to the frontend filter panel.
- Support multiple country selections while preserving existing filters.
- Add coverage for geocoder, NLP propagation, schema compatibility, repository queries, and API behavior.

## Validation

- Backend: 65 tests passing.
- Frontend production build passes.
- `git diff --check` passes.
- No changes to `App.tsx` or `GlobeViewer.tsx`.
- Existing events without country codes remain compatible.
- Country filtering is optional and does not affect unfiltered event queries.

Fixes #13