### PR TITLE
Feat #19: add intelligence export

### DIFF
--- a/backend/app/api/v1/endpoints/events.py
+++ b/backend/app/api/v1/endpoints/events.py
@@ -91,6 +91,76 @@ async def list_events(
     return EventListResponse(total=total, limit=limit, skip=skip, items=events)
 
 
+@router.get("/export", summary="Export Events to PDF or STIX")
+async def export_events(
+    format: str = Query(..., description="Export format: 'pdf' or 'stix'"),
+    threat_level: Optional[str] = Query(default=None, description="Filter by threat level: Low, Medium, High"),
+    min_threat_score: Optional[float] = Query(default=None, ge=0.0, le=100.0, description="Minimum threat score"),
+    event_type: Optional[str] = Query(default=None, description="Filter by event category"),
+    start_date: Optional[datetime] = Query(default=None, description="Start date (UTC ISO)"),
+    end_date: Optional[datetime] = Query(default=None, description="End date (UTC ISO)"),
+    bbox: Optional[str] = Query(default=None, description="Geospatial bounding box 'min_lon,min_lat,max_lon,max_lat'"),
+    search: Optional[str] = Query(default=None, description="Text search in title or summary"),
+    countries: Optional[str] = Query(default=None, description="Comma-separated ISO country codes (e.g. ua,ru)"),
+):
+    """Export filtered intelligence events to PDF or STIX 2.1 format."""
+    if format not in {"pdf", "stix"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported export format. Use 'pdf' or 'stix'."
+        )
+
+    if threat_level and threat_level not in {"Low", "Medium", "High"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid threat_level value. Allowed values: Low, Medium, High.",
+        )
+
+    parsed_bbox = parse_and_validate_bbox(bbox)
+
+    parsed_countries = None
+    if countries:
+        parsed_countries = list({c.strip().lower() for c in countries.split(",") if c.strip()})
+        if not parsed_countries:
+            parsed_countries = None
+
+    db = get_database()
+    event_repo = EventRepository(db)
+
+    # Use a safe absolute limit to prevent OOM
+    events = await event_repo.list_events(
+        limit=10000,
+        skip=0,
+        threat_level=threat_level,
+        min_threat_score=min_threat_score,
+        event_type=event_type,
+        start_date=start_date,
+        end_date=end_date,
+        bbox=parsed_bbox,
+        search=search,
+        countries=parsed_countries,
+    )
+
+    from app.intelligence.export_service import generate_pdf, generate_stix_bundle
+    from fastapi.responses import StreamingResponse
+    import io
+
+    if format == "pdf":
+        pdf_bytes = generate_pdf(events)
+        return StreamingResponse(
+            io.BytesIO(pdf_bytes),
+            media_type="application/pdf",
+            headers={"Content-Disposition": 'attachment; filename="threatatlas_export.pdf"'}
+        )
+    else:
+        stix_bytes = generate_stix_bundle(events)
+        return StreamingResponse(
+            io.BytesIO(stix_bytes),
+            media_type="application/stix+json",
+            headers={"Content-Disposition": 'attachment; filename="threatatlas_export.json"'}
+        )
+
+
 @router.get("/stats", response_model=EventGlobalMetrics, summary="Get Global Event Metrics")
 async def get_global_metrics():
     """Retrieve global un-filtered counts for Total, High, Medium, and Low threat events."""

--- a/backend/app/intelligence/export_service.py
+++ b/backend/app/intelligence/export_service.py
@@ -1,0 +1,121 @@
+import io
+import uuid
+import json
+from typing import List
+from datetime import datetime
+from html import escape
+from app.schemas.event import EventResponse
+
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer
+from reportlab.lib.colors import HexColor
+from stix2 import Incident, Bundle
+
+
+def generate_pdf(events: List[EventResponse]) -> bytes:
+    """Generate a simple PDF intelligence brief from a list of events."""
+    buffer = io.BytesIO()
+    doc = SimpleDocTemplate(buffer, pagesize=letter,
+                            rightMargin=40, leftMargin=40,
+                            topMargin=40, bottomMargin=40)
+
+    styles = getSampleStyleSheet()
+
+    # Custom styles
+    title_style = styles['Heading1']
+    event_title_style = styles['Heading3']
+
+    meta_style = ParagraphStyle(
+        'MetaStyle',
+        parent=styles['Normal'],
+        textColor=HexColor('#555555'),
+        fontSize=9,
+        spaceAfter=6
+    )
+
+    body_style = ParagraphStyle(
+        'BodyStyle',
+        parent=styles['Normal'],
+        spaceAfter=20,
+        leading=14
+    )
+
+    story = []
+
+    # Header
+    now_str = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+    story.append(Paragraph("ThreatAtlas Intelligence Export", title_style))
+    story.append(Paragraph(f"Generated: {now_str} | Total Events: {len(events)}", meta_style))
+    story.append(Spacer(1, 20))
+
+    for event in events:
+        # Event Title
+        story.append(Paragraph(escape(event.title), event_title_style))
+
+        # Meta info
+        meta_parts = [
+            f"Date: {event.event_timestamp.strftime('%Y-%m-%d %H:%M UTC')}",
+            f"Level: {escape(event.threat_level)} ({event.threat_score:.1f})",
+            f"Credibility: {event.credibility_score:.1f}",
+            f"Type: {escape(event.event_type or 'Unknown')}",
+        ]
+        if event.location_name:
+            meta_parts.append(f"Location: {escape(event.location_name)}")
+        if event.country_code:
+            meta_parts.append(f"Country: {escape(event.country_code.upper())}")
+
+        story.append(Paragraph(" | ".join(meta_parts), meta_style))
+
+        # Summary
+        summary = escape(event.summary or "No summary available.")
+        story.append(Paragraph(summary, body_style))
+
+    doc.build(story)
+    pdf_bytes = buffer.getvalue()
+    buffer.close()
+    return pdf_bytes
+
+
+def generate_stix_bundle(events: List[EventResponse]) -> bytes:
+    """Generate a STIX 2.1 Bundle containing an Incident SDO for each event."""
+    stix_objects = []
+
+    for event in events:
+        # Generate deterministic UUIDv5 from the MongoDB ObjectId string
+        event_uuid = uuid.uuid5(uuid.NAMESPACE_OID, str(event.id))
+        stix_id = f"incident--{event_uuid}"
+
+        # Build custom properties dictionary safely
+        custom_props = {
+            "x_threatatlas_score": event.threat_score,
+            "x_threatatlas_credibility": event.credibility_score,
+            "x_threatatlas_level": event.threat_level,
+        }
+
+        if event.country_code:
+            custom_props["x_threatatlas_country"] = event.country_code
+
+        if event.location and event.location.coordinates and len(event.location.coordinates) >= 2:
+            custom_props["x_threatatlas_location"] = {
+                "lon": float(event.location.coordinates[0]),
+                "lat": float(event.location.coordinates[1])
+            }
+
+        if event.event_type:
+            custom_props["x_threatatlas_type"] = event.event_type
+
+        # Create the Incident object
+        incident = Incident(
+            id=stix_id,
+            name=event.title,
+            description=event.summary or "No summary provided.",
+            created=event.created_at,
+            modified=event.updated_at,
+            allow_custom=True,  # Required by stix2 to allow x_ properties
+            **custom_props
+        )
+        stix_objects.append(incident)
+
+    bundle = Bundle(objects=stix_objects, allow_custom=True)
+    return bundle.serialize().encode("utf-8")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,5 @@ redis>=5.0.0,<6.0.0
 pyjwt>=2.8.0,<3.0.0
 passlib[bcrypt]>=1.7.4,<2.0.0
 apscheduler==3.10.4
+reportlab>=4.0.0
+stix2>=3.0.1

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -1,0 +1,157 @@
+import pytest
+import io
+import uuid
+import json
+from datetime import datetime, timezone
+from fastapi.testclient import TestClient
+
+from app.schemas.event import EventResponse
+from app.schemas.common import GeoJSONPoint
+from main import app
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+@pytest.fixture
+def test_events():
+    now = datetime.now(timezone.utc)
+    return [
+        EventResponse(
+            id="64f9b8c3d91234567890abcd",
+            title="Airstrike confirmed in capital",
+            summary="Multiple sources confirmed a kinetic airstrike.",
+            event_timestamp=now,
+            created_at=now,
+            updated_at=now,
+            threat_level="High",
+            threat_score=85.0,
+            credibility_score=90.0,
+            event_type="kinetic",
+            country_code="ua",
+            location_name="Kyiv",
+            location=GeoJSONPoint(coordinates=[30.5234, 50.4501])
+        ),
+        EventResponse(
+            id="64f9b8c3d91234567890abce",
+            title="Civilian protest",
+            summary="Peaceful gathering.",
+            event_timestamp=now,
+            created_at=now,
+            updated_at=now,
+            threat_level="Low",
+            threat_score=10.0,
+            credibility_score=60.0
+        )
+    ]
+
+def test_export_pdf_returns_pdf(client, mocker, test_events):
+    """1. Verify PDF export returns correct content type and signature."""
+    mocker.patch("app.api.v1.endpoints.events.get_database")
+    mocker.patch("app.db.repositories.event.EventRepository.list_events", return_value=test_events)
+    response = client.get("/api/v1/events/export?format=pdf")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/pdf"
+    assert "attachment" in response.headers["content-disposition"]
+    assert "threatatlas_export.pdf" in response.headers["content-disposition"]
+    assert response.content.startswith(b"%PDF-")
+
+def test_export_pdf_escaping_regression(client, mocker, test_events):
+    """Regression test: Verify PDF generation succeeds with problematic XML characters."""
+    test_events[0].title = "Bridge <damaged> & evacuation"
+    test_events[0].summary = "Attack caused <major> damage & disrupted infrastructure."
+    test_events[0].event_type = "kinetic <event>"
+
+    mocker.patch("app.api.v1.endpoints.events.get_database")
+    mocker.patch("app.db.repositories.event.EventRepository.list_events", return_value=[test_events[0]])
+
+    response = client.get("/api/v1/events/export?format=pdf")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/pdf"
+    assert response.content.startswith(b"%PDF-")
+
+
+def test_export_stix_returns_valid_bundle(client, mocker, test_events):
+    """2. Verify STIX export returns valid STIX 2.1 JSON parsable by stix2."""
+    mocker.patch("app.api.v1.endpoints.events.get_database")
+    mocker.patch("app.db.repositories.event.EventRepository.list_events", return_value=test_events)
+    response = client.get("/api/v1/events/export?format=stix")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/stix+json"
+    assert "threatatlas_export.json" in response.headers["content-disposition"]
+
+    from stix2 import parse
+    bundle = parse(response.content, allow_custom=True)
+    assert bundle.type == "bundle"
+    assert len(bundle.objects) == 2
+    assert bundle.objects[0].type == "incident"
+
+def test_export_field_mapping(client, mocker, test_events):
+    """3. Verify STIX fields map correctly and deterministic UUIDs are generated."""
+    mocker.patch("app.api.v1.endpoints.events.get_database")
+    mocker.patch("app.db.repositories.event.EventRepository.list_events", return_value=[test_events[0]])
+    response = client.get("/api/v1/events/export?format=stix")
+
+    data = response.json()
+    incident = data["objects"][0]
+
+    assert incident["name"] == "Airstrike confirmed in capital"
+    assert incident["description"] == "Multiple sources confirmed a kinetic airstrike."
+    assert "x_threatatlas_score" in incident
+    assert incident["x_threatatlas_score"] == 85.0
+    assert incident["x_threatatlas_country"] == "ua"
+    assert incident["x_threatatlas_location"]["lon"] == 30.5234
+
+    expected_uuid = str(uuid.uuid5(uuid.NAMESPACE_OID, "64f9b8c3d91234567890abcd"))
+    assert incident["id"] == f"incident--{expected_uuid}"
+
+def test_export_filters_respected(client, mocker):
+    """4. Verify export passes filters to repository query."""
+    mocker.patch("app.api.v1.endpoints.events.get_database")
+    list_spy = mocker.patch("app.db.repositories.event.EventRepository.list_events", return_value=[])
+
+    response = client.get("/api/v1/events/export?format=pdf&threat_level=High&countries=ua,ru&min_threat_score=50")
+    assert response.status_code == 200
+
+    list_spy.assert_called_once()
+    _, kwargs = list_spy.call_args
+    assert kwargs["threat_level"] == "High"
+    assert set(kwargs["countries"]) == {"ua", "ru"}
+    assert kwargs["min_threat_score"] == 50.0
+
+def test_export_invalid_format(client):
+    """5. Verify invalid format returns 400."""
+    response = client.get("/api/v1/events/export?format=csv")
+    assert response.status_code == 400
+    assert "Unsupported export format" in response.text
+
+def test_export_empty_result(client, mocker):
+    """6. Verify empty result exports correctly without crashing."""
+    mocker.patch("app.api.v1.endpoints.events.get_database")
+    mocker.patch("app.db.repositories.event.EventRepository.list_events", return_value=[])
+
+    pdf_res = client.get("/api/v1/events/export?format=pdf")
+    assert pdf_res.status_code == 200
+    assert pdf_res.content.startswith(b"%PDF-")
+
+    stix_res = client.get("/api/v1/events/export?format=stix")
+    assert stix_res.status_code == 200
+    data = stix_res.json()
+    assert len(data.get("objects", [])) == 0
+
+def test_export_no_internal_fields(client, mocker, test_events):
+    """7. Verify MongoDB internal fields (like raw_post_ids) aren't leaked in STIX."""
+    test_events[0].raw_post_ids = ["64f9b8c3d91234567890abcd"]
+    mocker.patch("app.api.v1.endpoints.events.get_database")
+    mocker.patch("app.db.repositories.event.EventRepository.list_events", return_value=[test_events[0]])
+
+    response = client.get("/api/v1/events/export?format=stix")
+    data = response.json()
+    incident = data["objects"][0]
+
+    assert "raw_post_ids" not in incident
+    json_str = json.dumps(incident)
+    assert "64f9b8c3d91234567890abcd" not in json_str  # ID shouldn't be exposed raw, only as UUIDv5

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -33,6 +33,47 @@ export const fetchEvents = async (filters: EventFilters = {}): Promise<EventList
   return response.data;
 };
 
+export const exportEvents = async (filters: EventFilters, format: 'pdf' | 'stix'): Promise<void> => {
+  const params: Record<string, any> = { format };
+  if (filters.threat_level) params.threat_level = filters.threat_level;
+  if (filters.min_threat_score) params.min_threat_score = filters.min_threat_score;
+  if (filters.search) params.search = filters.search;
+  if (filters.event_type) params.event_type = filters.event_type;
+  if (filters.bbox) params.bbox = filters.bbox;
+  if (filters.countries && filters.countries.length > 0) {
+    params.countries = filters.countries.join(',');
+  }
+
+  const response = await apiClient.get('/events/export', {
+    params,
+    responseType: 'blob', // Important for handling binary streams
+  });
+
+  // Trigger download
+  const blob = new Blob([response.data], {
+    type: format === 'pdf' ? 'application/pdf' : 'application/stix+json',
+  });
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+
+  // Extract filename from header if possible, else fallback
+  const contentDisposition = response.headers['content-disposition'];
+  let filename = format === 'pdf' ? 'threatatlas_export.pdf' : 'threatatlas_export.json';
+  if (contentDisposition) {
+    const filenameMatch = contentDisposition.match(/filename="?(.+)"?/i);
+    if (filenameMatch && filenameMatch.length === 2) {
+      filename = filenameMatch[1];
+    }
+  }
+
+  link.setAttribute('download', filename);
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.URL.revokeObjectURL(url);
+};
+
 export const fetchGlobalMetrics = async (): Promise<EventGlobalMetrics> => {
   const response = await apiClient.get<EventGlobalMetrics>('/events/stats');
   return response.data;

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Search, AlertTriangle, ShieldAlert, ShieldCheck, MapPin, Calendar, Globe, X, ChevronDown } from 'lucide-react';
 import type { Event, EventFilters, EventGlobalMetrics } from '../types';
-import { fetchAvailableCountries } from '../api/client';
+import { fetchAvailableCountries, exportEvents } from '../api/client';
 
 interface FilterPanelProps {
   filters: EventFilters;
@@ -23,6 +23,19 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
   const [availableCountries, setAvailableCountries] = useState<string[]>([]);
   const [isLoadingCountries, setIsLoadingCountries] = useState(false);
   const [isCountryDropdownOpen, setIsCountryDropdownOpen] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExport = async (format: 'pdf' | 'stix') => {
+    setIsExporting(true);
+    try {
+      await exportEvents(filters, format);
+    } catch (err) {
+      console.error('Failed to export events:', err);
+      alert('Failed to export events. Please try again.');
+    } finally {
+      setIsExporting(false);
+    }
+  };
 
   useEffect(() => {
     const loadCountries = async () => {
@@ -225,6 +238,24 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
               )}
             </div>
           )}
+        </div>
+
+        {/* Export Controls */}
+        <div className="pt-2 flex gap-2">
+          <button
+            onClick={() => handleExport('pdf')}
+            disabled={isExporting}
+            className="flex-1 py-1.5 bg-slate-800 hover:bg-slate-700 disabled:bg-slate-900 disabled:text-slate-600 border border-slate-700 rounded text-xs text-slate-200 font-mono transition-colors"
+          >
+            {isExporting ? 'Exporting...' : 'Export PDF'}
+          </button>
+          <button
+            onClick={() => handleExport('stix')}
+            disabled={isExporting}
+            className="flex-1 py-1.5 bg-slate-800 hover:bg-slate-700 disabled:bg-slate-900 disabled:text-slate-600 border border-slate-700 rounded text-xs text-slate-200 font-mono transition-colors"
+          >
+            {isExporting ? 'Exporting...' : 'Export STIX'}
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- Add filtered intelligence export to PDF.
- Add STIX 2.1 JSON export using Incident SDOs.
- Preserve active event filters during export.
- Add deterministic STIX IDs for repeatable exports.
- Add frontend Export PDF and Export STIX actions.
- Add safe ReportLab escaping for untrusted OSINT content.
- Limit exports to 10,000 events to prevent unbounded queries.
- Add comprehensive export and regression tests.

## Validation

- Issue #19 export tests: 8 passed.
- Full backend test suite: 79 passed.
- Frontend production build passes.
- `git diff --check` passes.
- PDF generation handles special characters safely.
- STIX 2.1 bundles validate successfully.
- Existing filtering behavior is preserved.
- No GlobeViewer, App, NLP, ingestion, worker, or webhook logic was modified.

Fixes #19