### PR TITLE
Feat #20: add geofenced webhook alerts

### DIFF
--- a/backend/app/api/v1/endpoints/webhooks.py
+++ b/backend/app/api/v1/endpoints/webhooks.py
@@ -1,0 +1,82 @@
+from typing import List
+from fastapi import APIRouter, HTTPException, status
+from app.schemas.webhook import WebhookAlertCreate, WebhookAlertUpdate, WebhookAlertResponse
+from app.db.repositories.webhook import WebhookRepository
+from app.db.session import get_database
+from app.services.webhook_service import validate_webhook_url, SecurityValidationError
+
+router = APIRouter()
+
+@router.post("", response_model=WebhookAlertResponse, status_code=status.HTTP_201_CREATED, summary="Create Webhook")
+async def create_webhook(webhook_in: WebhookAlertCreate):
+    try:
+        validate_webhook_url(webhook_in.url)
+    except SecurityValidationError as e:
+        # Don't leak the exact resolved IP in error message to prevent probing, just give the exception string.
+        raise HTTPException(status_code=400, detail=str(e))
+        
+    db = get_database()
+    repo = WebhookRepository(db)
+    return await repo.create(webhook_in)
+
+@router.get("", response_model=List[WebhookAlertResponse], summary="List Webhooks")
+async def list_webhooks():
+    db = get_database()
+    repo = WebhookRepository(db)
+    return await repo.list_webhooks()
+
+@router.patch("/{id}", response_model=WebhookAlertResponse, summary="Update Webhook")
+async def update_webhook(id: str, webhook_in: WebhookAlertUpdate):
+    if webhook_in.url is not None:
+        try:
+            validate_webhook_url(webhook_in.url)
+        except SecurityValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+            
+    db = get_database()
+    repo = WebhookRepository(db)
+    updated = await repo.update(id, webhook_in)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+    return updated
+
+@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT, summary="Delete Webhook")
+async def delete_webhook(id: str):
+    db = get_database()
+    repo = WebhookRepository(db)
+    deleted = await repo.delete(id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+
+@router.post("/{id}/test", summary="Test Webhook")
+async def test_webhook(id: str):
+    db = get_database()
+    repo = WebhookRepository(db)
+    webhook = await repo.get_by_id(id)
+    if not webhook:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+        
+    from datetime import datetime, timezone
+    from app.schemas.event import EventResponse
+    from app.services.webhook_service import dispatch_webhook
+    
+    # Create a safe fake event
+    test_event = EventResponse(
+        id="000000000000000000000000",
+        title="Test Threat Event",
+        summary="This is a test event to verify webhook delivery.",
+        raw_post_ids=[],
+        source_ids=[],
+        threat_level="High",
+        threat_score=100.0,
+        credibility_score=100.0,
+        event_type="test",
+        event_timestamp=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc)
+    )
+    
+    success = await dispatch_webhook(webhook, test_event)
+    if not success:
+        raise HTTPException(status_code=500, detail="Webhook delivery failed. Check URL and server status.")
+    return {"status": "success", "detail": "Test payload delivered."}

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -4,6 +4,7 @@ from app.api.v1.endpoints.raw_posts import router as raw_posts_router
 from app.api.v1.endpoints.intelligence import router as intelligence_router
 from app.api.v1.endpoints.auth import router as auth_router
 from app.api.v1.endpoints.websockets import router as websockets_router
+from app.api.v1.endpoints.webhooks import router as webhooks_router
 
 v1_router = APIRouter()
 
@@ -12,3 +13,4 @@ v1_router.include_router(events_router, prefix="/events", tags=["Events"])
 v1_router.include_router(raw_posts_router, prefix="/raw-posts", tags=["Raw Posts"])
 v1_router.include_router(intelligence_router, prefix="/intelligence", tags=["Intelligence"])
 v1_router.include_router(websockets_router, prefix="/ws", tags=["WebSockets"])
+v1_router.include_router(webhooks_router, prefix="/webhooks", tags=["Webhooks"])

--- a/backend/app/db/repositories/webhook.py
+++ b/backend/app/db/repositories/webhook.py
@@ -1,0 +1,66 @@
+from typing import List, Optional
+from datetime import datetime, timezone
+from bson import ObjectId
+from pymongo.collection import Collection
+from pymongo.database import Database
+from pydantic import ValidationError
+
+from app.schemas.webhook import WebhookAlertCreate, WebhookAlertResponse, WebhookAlertUpdate
+
+
+class WebhookRepository:
+    def __init__(self, db: Database):
+        self.collection: Collection = db["webhooks"]
+
+    async def get_by_id(self, webhook_id: str) -> Optional[WebhookAlertResponse]:
+        if not ObjectId.is_valid(webhook_id):
+            return None
+        doc = await self.collection.find_one({"_id": ObjectId(webhook_id)})
+        if doc:
+            return WebhookAlertResponse(**doc)
+        return None
+
+    async def list_webhooks(self, active_only: bool = False) -> List[WebhookAlertResponse]:
+        query = {}
+        if active_only:
+            query["is_active"] = True
+        
+        cursor = self.collection.find(query).sort("created_at", -1)
+        docs = await cursor.to_list(length=1000)
+        return [WebhookAlertResponse(**doc) for doc in docs]
+
+    async def create(self, webhook_in: WebhookAlertCreate) -> WebhookAlertResponse:
+        doc = webhook_in.model_dump()
+        now = datetime.now(timezone.utc)
+        doc["created_at"] = now
+        doc["updated_at"] = now
+
+        result = await self.collection.insert_one(doc)
+        created_doc = await self.collection.find_one({"_id": result.inserted_id})
+        return WebhookAlertResponse(**created_doc)
+
+    async def update(self, webhook_id: str, webhook_in: WebhookAlertUpdate) -> Optional[WebhookAlertResponse]:
+        if not ObjectId.is_valid(webhook_id):
+            return None
+
+        update_data = {k: v for k, v in webhook_in.model_dump().items() if v is not None}
+        if not update_data:
+            return await self.get_by_id(webhook_id)
+
+        update_data["updated_at"] = datetime.now(timezone.utc)
+
+        result = await self.collection.update_one(
+            {"_id": ObjectId(webhook_id)},
+            {"$set": update_data}
+        )
+
+        if result.matched_count == 0:
+            return None
+
+        return await self.get_by_id(webhook_id)
+
+    async def delete(self, webhook_id: str) -> bool:
+        if not ObjectId.is_valid(webhook_id):
+            return False
+        result = await self.collection.delete_one({"_id": ObjectId(webhook_id)})
+        return result.deleted_count > 0

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -92,11 +92,21 @@ async def init_db() -> None:
         ),
     ]
 
+    # Webhooks Collection Indexes
+    webhooks_indexes = [
+        IndexModel(
+            [("is_active", ASCENDING)],
+            name="idx_webhooks_is_active",
+        ),
+    ]
+
     try:
         logger.info("Creating indexes for raw_posts collection...")
         await db.raw_posts.create_indexes(raw_posts_indexes)
         logger.info("Creating indexes for events collection...")
         await db.events.create_indexes(events_indexes)
+        logger.info("Creating indexes for webhooks collection...")
+        await db.webhooks.create_indexes(webhooks_indexes)
         logger.info("MongoDB indexes created successfully.")
     except Exception as e:
         logger.warning("Index creation notice/warning: %s", str(e))

--- a/backend/app/intelligence/service.py
+++ b/backend/app/intelligence/service.py
@@ -1,4 +1,5 @@
 import logging
+import asyncio
 from typing import Any, Dict, List, Optional
 from app.nlp.schemas import NLPResult
 from app.nlp.service import nlp_service
@@ -11,6 +12,7 @@ from app.intelligence.threat_scorer import calculate_threat_score, is_post_relev
 from app.intelligence.credibility_scorer import calculate_credibility_score
 from app.intelligence.clustering import find_best_matching_event
 from app.core.redis import publish_event
+from app.services.webhook_service import dispatch_webhooks_for_event
 
 logger = logging.getLogger("threat_atlas.intelligence")
 
@@ -172,6 +174,7 @@ class IntelligenceService:
 
             if created_event:
                 await publish_event(created_event.model_dump(), action="created")
+                asyncio.create_task(dispatch_webhooks_for_event(created_event))
 
             return {
                 "action": "created",

--- a/backend/app/schemas/webhook.py
+++ b/backend/app/schemas/webhook.py
@@ -1,0 +1,107 @@
+from typing import Optional, List, Literal
+from datetime import datetime, timezone
+from pydantic import BaseModel, Field, validator
+from app.schemas.common import PyObjectId
+from bson import ObjectId
+
+
+class WebhookAlertBase(BaseModel):
+    url: str = Field(..., description="Webhook URL (must be http or https)")
+    provider: Literal["discord", "slack", "generic"] = Field(..., description="Target provider format")
+    is_active: bool = Field(default=True)
+    min_threat_level: Literal["High", "Critical"] = Field(default="High")
+    countries: Optional[List[str]] = Field(default=None, description="List of ISO 3166-1 alpha-2 country codes")
+    bbox: Optional[List[List[float]]] = Field(
+        default=None,
+        description="Geographic bounding box: [[min_lon, min_lat], [max_lon, max_lat]]"
+    )
+
+    @validator("url")
+    def validate_url_scheme(cls, v):
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("URL must start with http:// or https://")
+        return v
+
+    @validator("countries", pre=True)
+    def normalize_countries(cls, v):
+        if v is None:
+            return v
+        if not isinstance(v, list):
+            raise ValueError("countries must be a list")
+        # Normalize to lowercase and reject empty
+        normalized = []
+        for c in v:
+            if not isinstance(c, str):
+                raise ValueError("Country code must be a string")
+            c = c.strip().lower()
+            if not c or len(c) != 2:
+                raise ValueError("Country code must be 2 characters")
+            normalized.append(c)
+        return normalized if normalized else None
+
+    @validator("bbox")
+    def validate_bbox(cls, v):
+        if v is None:
+            return v
+        if len(v) != 2 or len(v[0]) != 2 or len(v[1]) != 2:
+            raise ValueError("bbox must be in format [[min_lon, min_lat], [max_lon, max_lat]]")
+        min_lon, min_lat = v[0]
+        max_lon, max_lat = v[1]
+        if not (-180 <= min_lon <= 180 and -180 <= max_lon <= 180):
+            raise ValueError("Longitude must be between -180 and 180")
+        if not (-90 <= min_lat <= 90 and -90 <= max_lat <= 90):
+            raise ValueError("Latitude must be between -90 and 90")
+        if min_lon > max_lon or min_lat > max_lat:
+            raise ValueError("Invalid bounding box min/max ordering")
+        return v
+
+
+class WebhookAlertCreate(WebhookAlertBase):
+    pass
+
+
+class WebhookAlertUpdate(BaseModel):
+    url: Optional[str] = None
+    provider: Optional[Literal["discord", "slack", "generic"]] = None
+    is_active: Optional[bool] = None
+    min_threat_level: Optional[Literal["High", "Critical"]] = None
+    countries: Optional[List[str]] = None
+    bbox: Optional[List[List[float]]] = None
+
+    @validator("url")
+    def validate_url_scheme(cls, v):
+        if v is not None and not v.startswith(("http://", "https://")):
+            raise ValueError("URL must start with http:// or https://")
+        return v
+
+    @validator("countries", pre=True)
+    def normalize_countries(cls, v):
+        if v is None:
+            return v
+        if not isinstance(v, list):
+            raise ValueError("countries must be a list")
+        normalized = [c.strip().lower() for c in v if isinstance(c, str) and c.strip()]
+        return normalized if normalized else None
+
+    @validator("bbox")
+    def validate_bbox(cls, v):
+        if v is None:
+            return v
+        if len(v) != 2 or len(v[0]) != 2 or len(v[1]) != 2:
+            raise ValueError("bbox must be in format [[min_lon, min_lat], [max_lon, max_lat]]")
+        min_lon, min_lat = v[0]
+        max_lon, max_lat = v[1]
+        if min_lon > max_lon or min_lat > max_lat:
+            raise ValueError("Invalid bounding box min/max ordering")
+        return v
+
+
+class WebhookAlertResponse(WebhookAlertBase):
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        populate_by_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str, datetime: lambda dt: dt.isoformat()}

--- a/backend/app/services/webhook_service.py
+++ b/backend/app/services/webhook_service.py
@@ -1,0 +1,246 @@
+import logging
+import socket
+import ipaddress
+from urllib.parse import urlparse
+import httpx
+from typing import Optional, List, Dict, Any
+from app.schemas.event import EventResponse
+from app.schemas.webhook import WebhookAlertResponse
+from app.db.repositories.webhook import WebhookRepository
+from app.db.session import get_database
+
+try:
+    from httpcore._backends.auto import AutoBackend
+except ImportError:
+    # Fallback if httpcore internal paths change
+    AutoBackend = None
+
+logger = logging.getLogger("threat_atlas.webhooks")
+
+class SecurityValidationError(Exception):
+    pass
+
+def validate_webhook_url(url: str) -> str:
+    """
+    Strict URL validation to prevent SSRF.
+    Validates scheme and resolves hostname to ensure it's a public IP.
+    """
+    if not url.startswith(("http://", "https://")):
+        raise SecurityValidationError("URL scheme must be http or https.")
+    
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        raise SecurityValidationError("URL must contain a valid hostname.")
+        
+    if parsed.username or parsed.password:
+        raise SecurityValidationError("Credentials in webhook URLs are not permitted.")
+        
+    if parsed.port and parsed.port not in (80, 443):
+        raise SecurityValidationError("Only ports 80 and 443 are allowed.")
+        
+    try:
+        # Resolve hostname. This returns a list of (family, type, proto, canonname, sockaddr)
+        addr_info = socket.getaddrinfo(hostname, parsed.port or 80)
+    except socket.gaierror as e:
+        raise SecurityValidationError(f"Could not resolve hostname: {str(e)}")
+        
+    for res in addr_info:
+        ip = res[4][0]
+        try:
+            ip_obj = ipaddress.ip_address(ip)
+        except ValueError:
+            continue
+            
+        if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_multicast or \
+           ip_obj.is_link_local or ip_obj.is_unspecified:
+            raise SecurityValidationError(f"URL resolves to a non-public IP address: {ip}")
+            
+        # Return the first safe IP found
+        return ip
+        
+    raise SecurityValidationError("Could not find a valid IP address.")
+
+class SafeNetworkBackend:
+    """
+    A custom httpcore network backend that forces connections to a specific pre-resolved IP.
+    This prevents DNS Rebinding TOCTOU SSRF vulnerabilities where httpx's internal DNS 
+    resolution might fetch a different IP than the one we validated.
+    """
+    def __init__(self, safe_ip: str):
+        self.backend = AutoBackend()
+        self.safe_ip = safe_ip
+        
+    async def connect_tcp(self, host: str, port: int, timeout: Optional[float] = None, local_address: Optional[str] = None, **kwargs) -> Any:
+        # Override the destination host IP but leave SNI/TLS verification intact
+        return await self.backend.connect_tcp(self.safe_ip, port, timeout=timeout, local_address=local_address, **kwargs)
+        
+    async def connect_unix_socket(self, *args, **kwargs) -> Any:
+        return await self.backend.connect_unix_socket(*args, **kwargs)
+        
+    async def sleep(self, *args, **kwargs) -> Any:
+        return await self.backend.sleep(*args, **kwargs)
+
+def _build_discord_payload(event: EventResponse) -> dict:
+    color = 15158332 if event.threat_level in ["High", "Critical"] else 16776960
+    
+    return {
+        "content": f"**New {event.threat_level} Severity Threat Alert**",
+        "embeds": [{
+            "title": event.title,
+            "description": event.summary or "No summary available",
+            "color": color,
+            "fields": [
+                {"name": "Threat Score", "value": str(round(event.threat_score, 1)), "inline": True},
+                {"name": "Credibility", "value": str(round(event.credibility_score, 1)), "inline": True},
+                {"name": "Country", "value": (event.country_code.upper() if event.country_code else "Unknown"), "inline": True},
+                {"name": "Location", "value": event.location_name or "Unknown", "inline": True},
+                {"name": "Event Type", "value": event.event_type or "Unknown", "inline": True},
+                {"name": "Timestamp", "value": event.event_timestamp.strftime('%Y-%m-%d %H:%M UTC'), "inline": True},
+            ],
+            "footer": {"text": f"ThreatAtlas Intelligence | Event ID: {event.id}"}
+        }]
+    }
+
+def _build_slack_payload(event: EventResponse) -> dict:
+    return {
+        "text": f"*New {event.threat_level} Severity Threat Alert*\n*{event.title}*",
+        "blocks": [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": f"{event.threat_level} Severity Threat: {event.title}"
+                }
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": event.summary or "No summary available"
+                }
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {"type": "mrkdwn", "text": f"*Threat Score:*\n{round(event.threat_score, 1)}"},
+                    {"type": "mrkdwn", "text": f"*Credibility:*\n{round(event.credibility_score, 1)}"},
+                    {"type": "mrkdwn", "text": f"*Country:*\n{event.country_code.upper() if event.country_code else 'Unknown'}"},
+                    {"type": "mrkdwn", "text": f"*Location:*\n{event.location_name or 'Unknown'}"},
+                ]
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {"type": "plain_text", "text": f"ThreatAtlas Intelligence | Event ID: {event.id}"}
+                ]
+            }
+        ]
+    }
+
+def _build_generic_payload(event: EventResponse) -> dict:
+    return {
+        "event_id": str(event.id),
+        "title": event.title,
+        "summary": event.summary,
+        "threat_level": event.threat_level,
+        "threat_score": event.threat_score,
+        "credibility_score": event.credibility_score,
+        "event_type": event.event_type,
+        "timestamp": event.event_timestamp.isoformat(),
+        "location_name": event.location_name,
+        "country_code": event.country_code,
+        "coordinates": event.location.coordinates if event.location and event.location.coordinates else None
+    }
+
+def is_event_matching_webhook(event: EventResponse, webhook: WebhookAlertResponse) -> bool:
+    """Returns True if the event satisfies the webhook's geofence and threat conditions."""
+    if not webhook.is_active:
+        return False
+        
+    # Threat Level Matching
+    if webhook.min_threat_level in ["High", "Critical"]:
+        # Only High and Critical are supported right now, and both should match High/Critical events.
+        if event.threat_level not in ["High", "Critical"]:
+            return False
+
+    # Country matching
+    if webhook.countries:
+        if not event.country_code:
+            return False
+        if event.country_code.lower() not in webhook.countries:
+            return False
+            
+    # Bounding Box matching
+    if webhook.bbox:
+        if not event.location or not event.location.coordinates or len(event.location.coordinates) < 2:
+            return False
+            
+        lng = event.location.coordinates[0]
+        lat = event.location.coordinates[1]
+        
+        min_lon, min_lat = webhook.bbox[0]
+        max_lon, max_lat = webhook.bbox[1]
+        
+        if not (min_lon <= lng <= max_lon and min_lat <= lat <= max_lat):
+            return False
+            
+    return True
+
+async def dispatch_webhook(webhook: WebhookAlertResponse, event: EventResponse) -> bool:
+    """Dispatches a single webhook safely without raising exceptions."""
+    try:
+        safe_ip = validate_webhook_url(webhook.url)
+    except SecurityValidationError as e:
+        logger.error(f"Webhook {webhook.id} SSRF validation failed: {e}")
+        return False
+
+    if webhook.provider == "discord":
+        payload = _build_discord_payload(event)
+    elif webhook.provider == "slack":
+        payload = _build_slack_payload(event)
+    else:
+        payload = _build_generic_payload(event)
+        
+    try:
+        if AutoBackend is not None:
+            transport = httpx.AsyncHTTPTransport(retries=0)
+            transport._pool._network_backend = SafeNetworkBackend(safe_ip)
+            client_kwargs = {"transport": transport, "timeout": 3.0, "follow_redirects": False}
+        else:
+            client_kwargs = {"timeout": 3.0, "follow_redirects": False}
+
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            response = await client.post(webhook.url, json=payload)
+            response.raise_for_status()
+            logger.info(f"Webhook {webhook.id} delivered successfully (Status {response.status_code})")
+            return True
+    except httpx.TimeoutException:
+        logger.error(f"Webhook {webhook.id} delivery timed out.")
+    except httpx.HTTPError as e:
+        logger.error(f"Webhook {webhook.id} HTTP error: {e}")
+    except Exception as e:
+        logger.error(f"Webhook {webhook.id} unexpected error: {e}")
+        
+    return False
+
+async def dispatch_webhooks_for_event(event: EventResponse) -> None:
+    """
+    Evaluates all active webhooks for a newly created event and dispatches them asynchronously.
+    Exceptions are suppressed so this never crashes the caller pipeline.
+    """
+    try:
+        if event.threat_level not in ["High", "Critical"]:
+            return
+            
+        db = get_database()
+        repo = WebhookRepository(db)
+        
+        active_webhooks = await repo.list_webhooks(active_only=True)
+        for webhook in active_webhooks:
+            if is_event_matching_webhook(event, webhook):
+                # We could dispatch them concurrently, but sequential awaiting in a background task
+                # is fine for MVP. The outer caller runs this whole function via create_task.
+                await dispatch_webhook(webhook, event)
+    except Exception as e:
+        logger.error(f"Error evaluating webhooks for event {event.id}: {e}", exc_info=True)

--- a/backend/tests/test_webhooks.py
+++ b/backend/tests/test_webhooks.py
@@ -1,0 +1,209 @@
+import pytest
+import httpx
+from datetime import datetime, timezone
+from pydantic import ValidationError
+from app.schemas.webhook import WebhookAlertCreate, WebhookAlertUpdate
+from app.schemas.event import EventResponse, GeoJSONPoint
+from fastapi.testclient import TestClient
+from main import app
+from app.services.webhook_service import (
+    validate_webhook_url, SecurityValidationError, is_event_matching_webhook, dispatch_webhook, dispatch_webhooks_for_event
+)
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+@pytest.fixture
+def sample_event():
+    return EventResponse(
+        id="111111111111111111111111",
+        title="Test Event",
+        summary="Test summary",
+        raw_post_ids=[],
+        source_ids=[],
+        threat_level="High",
+        threat_score=95.0,
+        credibility_score=90.0,
+        event_type="kinetic",
+        country_code="ua",
+        location=GeoJSONPoint(coordinates=[30.0, 50.0]),
+        event_timestamp=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc)
+    )
+
+def test_schema_valid_webhook():
+    w = WebhookAlertCreate(url="https://example.com/webhook", provider="discord", min_threat_level="High", countries=["UA", " RU "])
+    assert w.countries == ["ua", "ru"]
+    
+def test_schema_invalid_url():
+    with pytest.raises(ValidationError):
+        WebhookAlertCreate(url="ftp://example.com", provider="slack")
+        
+def test_schema_invalid_bbox():
+    with pytest.raises(ValidationError):
+        # min_lon > max_lon
+        WebhookAlertCreate(url="https://example.com", provider="generic", bbox=[[40.0, 40.0], [30.0, 50.0]])
+
+def test_security_validation_ssrf(mocker):
+    # Test valid URL
+    mocker.patch("socket.getaddrinfo", return_value=[(None, None, None, None, ("8.8.8.8", 80))])
+    validate_webhook_url("https://safe-domain.com")
+
+    # Test loopback IP
+    mocker.patch("socket.getaddrinfo", return_value=[(None, None, None, None, ("127.0.0.1", 80))])
+    with pytest.raises(SecurityValidationError, match="non-public IP address"):
+        validate_webhook_url("https://malicious.com")
+
+    # Test metadata service IP
+    mocker.patch("socket.getaddrinfo", return_value=[(None, None, None, None, ("169.254.169.254", 80))])
+    with pytest.raises(SecurityValidationError, match="non-public IP address"):
+        validate_webhook_url("https://cloud-metadata.internal")
+
+@pytest.mark.asyncio
+async def test_dns_rebinding_protection_at_transport(mocker, sample_event):
+    """
+    Ensures that the SafeNetworkBackend actually forces httpx to connect 
+    to the pre-validated IP, completely ignoring any secondary DNS resolution.
+    """
+    from app.services.webhook_service import SafeNetworkBackend, AutoBackend
+    
+    # 1. We have a webhook URL targeting 'malicious-rebind.com'
+    w = WebhookAlertCreate(url="https://malicious-rebind.com", provider="generic").model_dump()
+    w["is_active"] = True
+    w["_id"] = "222222222222222222222222"
+    w["created_at"] = datetime.now(timezone.utc)
+    w["updated_at"] = datetime.now(timezone.utc)
+    from app.schemas.webhook import WebhookAlertResponse
+    webhook = WebhookAlertResponse(**w)
+    
+    # 2. Mock validate_webhook_url to return our safe IP ('8.8.8.8')
+    mocker.patch("app.services.webhook_service.validate_webhook_url", return_value="8.8.8.8")
+    
+    # 3. We must mock the transport's actual connection at httpx level, 
+    # but to prove AutoBackend was used with 8.8.8.8, we can mock 
+    # AutoBackend.connect_tcp directly and provide a fake stream.
+    
+    class FakeStream:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *args): pass
+        def get_extra_info(self, name): return None
+        async def read(self, *args, **kwargs): return b""
+        async def write(self, *args, **kwargs): pass
+        async def aclose(self): pass
+        
+    mock_connect = mocker.AsyncMock(return_value=FakeStream())
+    mocker.patch.object(AutoBackend, "connect_tcp", mock_connect)
+    
+    # 5. Dispatch
+    await dispatch_webhook(webhook, sample_event)
+    
+    # 6. Verify that the inner socket connection received "8.8.8.8" regardless of "malicious-rebind.com"
+    mock_connect.assert_called_once()
+    args, kwargs = mock_connect.call_args
+    assert args[0] == "8.8.8.8"  # Since it's patched on the class/method, args[0] is the host if not bound
+
+def test_matching_threat_level(sample_event):
+    w = WebhookAlertCreate(url="https://x", provider="slack").model_dump()
+    w["is_active"] = True
+    w["_id"] = "222222222222222222222222"
+    w["created_at"] = datetime.now(timezone.utc)
+    w["updated_at"] = datetime.now(timezone.utc)
+    from app.schemas.webhook import WebhookAlertResponse
+    webhook = WebhookAlertResponse(**w)
+    
+    assert is_event_matching_webhook(sample_event, webhook) == True
+    
+    sample_event.threat_level = "Medium"
+    assert is_event_matching_webhook(sample_event, webhook) == False
+
+def test_matching_country(sample_event):
+    w = WebhookAlertCreate(url="https://x", provider="slack", countries=["ru"]).model_dump()
+    w["is_active"] = True
+    w["_id"] = "222222222222222222222222"
+    w["created_at"] = datetime.now(timezone.utc)
+    w["updated_at"] = datetime.now(timezone.utc)
+    from app.schemas.webhook import WebhookAlertResponse
+    webhook = WebhookAlertResponse(**w)
+    
+    assert is_event_matching_webhook(sample_event, webhook) == False  # event is UA
+    
+    webhook.countries = ["ua"]
+    assert is_event_matching_webhook(sample_event, webhook) == True
+
+def test_matching_bbox(sample_event):
+    w = WebhookAlertCreate(url="https://x", provider="slack", bbox=[[20.0, 40.0], [40.0, 60.0]]).model_dump()
+    w["is_active"] = True
+    w["_id"] = "222222222222222222222222"
+    w["created_at"] = datetime.now(timezone.utc)
+    w["updated_at"] = datetime.now(timezone.utc)
+    from app.schemas.webhook import WebhookAlertResponse
+    webhook = WebhookAlertResponse(**w)
+    
+    # Event is at 30.0, 50.0 (inside)
+    assert is_event_matching_webhook(sample_event, webhook) == True
+    
+    # Move event outside
+    sample_event.location.coordinates = [0.0, 0.0]
+    assert is_event_matching_webhook(sample_event, webhook) == False
+    
+    # Missing location
+    sample_event.location = None
+    assert is_event_matching_webhook(sample_event, webhook) == False
+
+@pytest.mark.asyncio
+async def test_dispatch_delivery_failure_isolation(mocker, sample_event):
+    w = WebhookAlertCreate(url="https://safe-domain.com", provider="generic").model_dump()
+    w["is_active"] = True
+    w["_id"] = "222222222222222222222222"
+    w["created_at"] = datetime.now(timezone.utc)
+    w["updated_at"] = datetime.now(timezone.utc)
+    from app.schemas.webhook import WebhookAlertResponse
+    webhook = WebhookAlertResponse(**w)
+
+    mocker.patch("app.services.webhook_service.validate_webhook_url", return_value=None)
+    
+    class MockClient:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *args): pass
+        async def post(self, *args, **kwargs):
+            raise httpx.TimeoutException("Timeout")
+            
+    mocker.patch("httpx.AsyncClient", return_value=MockClient())
+    
+    # Should safely return False without raising
+    result = await dispatch_webhook(webhook, sample_event)
+    assert result == False
+
+@pytest.mark.asyncio
+async def test_crud_endpoints(client, mocker):
+    mocker.patch("app.api.v1.endpoints.events.get_database")
+    mocker.patch("app.api.v1.endpoints.webhooks.get_database")
+    # Actually need a real DB or mocked repo
+    # To test easily without real DB, mock the WebhookRepository
+    from app.schemas.webhook import WebhookAlertResponse
+    fake_webhook = WebhookAlertResponse(
+        _id="333333333333333333333333",
+        url="https://test.com",
+        provider="discord",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc)
+    )
+    
+    mocker.patch("app.api.v1.endpoints.webhooks.WebhookRepository.create", new_callable=mocker.AsyncMock, return_value=fake_webhook)
+    mocker.patch("app.api.v1.endpoints.webhooks.WebhookRepository.list_webhooks", new_callable=mocker.AsyncMock, return_value=[fake_webhook])
+    mocker.patch("app.api.v1.endpoints.webhooks.WebhookRepository.delete", new_callable=mocker.AsyncMock, return_value=True)
+    
+    # Mock validate_url
+    mocker.patch("app.api.v1.endpoints.webhooks.validate_webhook_url", return_value=None)
+    
+    res = client.post("/api/v1/webhooks", json={"url": "https://test.com", "provider": "discord"})
+    assert res.status_code == 201
+    
+    res = client.get("/api/v1/webhooks")
+    assert res.status_code == 200
+    assert len(res.json()) == 1
+    
+    res = client.delete("/api/v1/webhooks/333333333333333333333333")
+    assert res.status_code == 204

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,6 +7,9 @@ import type {
   RawPost,
   RawPostListResponse,
   EventGlobalMetrics,
+  WebhookAlert,
+  WebhookAlertCreate,
+  WebhookAlertUpdate,
 } from '../types';
 
 const API_BASE_URL = '/api/v1';
@@ -115,4 +118,29 @@ export const checkHealth = async (): Promise<boolean> => {
   } catch (err) {
     return false;
   }
+};
+
+// Webhooks API
+export const fetchWebhooks = async (): Promise<WebhookAlert[]> => {
+  const response = await apiClient.get<WebhookAlert[]>('/webhooks');
+  return response.data;
+};
+
+export const createWebhook = async (data: WebhookAlertCreate): Promise<WebhookAlert> => {
+  const response = await apiClient.post<WebhookAlert>('/webhooks', data);
+  return response.data;
+};
+
+export const updateWebhook = async (id: string, data: WebhookAlertUpdate): Promise<WebhookAlert> => {
+  const response = await apiClient.patch<WebhookAlert>(`/webhooks/${id}`, data);
+  return response.data;
+};
+
+export const deleteWebhook = async (id: string): Promise<void> => {
+  await apiClient.delete(`/webhooks/${id}`);
+};
+
+export const testWebhook = async (id: string): Promise<{ status: string, detail: string }> => {
+  const response = await apiClient.post<{ status: string, detail: string }>(`/webhooks/${id}/test`);
+  return response.data;
 };

--- a/frontend/src/components/AlertsModal.tsx
+++ b/frontend/src/components/AlertsModal.tsx
@@ -1,0 +1,229 @@
+import React, { useState, useEffect } from 'react';
+import { fetchWebhooks, createWebhook, deleteWebhook, testWebhook, updateWebhook } from '../api/client';
+import type { WebhookAlert, WebhookAlertCreate } from '../types';
+
+interface AlertsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const AlertsModal: React.FC<AlertsModalProps> = ({ isOpen, onClose }) => {
+  const [webhooks, setWebhooks] = useState<WebhookAlert[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [url, setUrl] = useState('');
+  const [provider, setProvider] = useState<'discord' | 'slack' | 'generic'>('discord');
+  const [countriesInput, setCountriesInput] = useState('');
+
+  const loadWebhooks = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await fetchWebhooks();
+      setWebhooks(data);
+    } catch (err: any) {
+      setError(err.response?.data?.detail || err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      loadWebhooks();
+    }
+  }, [isOpen]);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      setError(null);
+      const countries = countriesInput.split(',').map(c => c.trim()).filter(c => c.length > 0);
+      
+      const payload: WebhookAlertCreate = {
+        url,
+        provider,
+        min_threat_level: 'High',
+        is_active: true,
+        countries: countries.length > 0 ? countries : undefined,
+      };
+
+      await createWebhook(payload);
+      setUrl('');
+      setCountriesInput('');
+      await loadWebhooks();
+    } catch (err: any) {
+      setError(err.response?.data?.detail || err.message);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm('Are you sure you want to delete this alert?')) return;
+    try {
+      setError(null);
+      await deleteWebhook(id);
+      await loadWebhooks();
+    } catch (err: any) {
+      setError(err.response?.data?.detail || err.message);
+    }
+  };
+
+  const handleTest = async (id: string) => {
+    try {
+      setError(null);
+      await testWebhook(id);
+      alert('Test payload sent successfully!');
+    } catch (err: any) {
+      setError(err.response?.data?.detail || err.message);
+    }
+  };
+
+  const handleToggleActive = async (webhook: WebhookAlert) => {
+    try {
+      setError(null);
+      await updateWebhook(webhook.id, { is_active: !webhook.is_active });
+      await loadWebhooks();
+    } catch (err: any) {
+      setError(err.response?.data?.detail || err.message);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-60 z-50 flex justify-center items-center backdrop-blur-sm">
+      <div className="bg-gray-800 rounded-xl shadow-2xl w-full max-w-3xl overflow-hidden flex flex-col max-h-[85vh] border border-gray-700">
+        <div className="p-4 border-b border-gray-700 flex justify-between items-center bg-gray-900">
+          <h2 className="text-xl font-bold text-white flex items-center">
+            <span className="text-red-500 mr-2">🔔</span> Webhook Alerts
+          </h2>
+          <button 
+            onClick={onClose}
+            className="text-gray-400 hover:text-white transition-colors"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-6 flex flex-col space-y-6">
+          {error && (
+            <div className="bg-red-500 bg-opacity-10 border border-red-500 text-red-500 p-3 rounded text-sm">
+              {error}
+            </div>
+          )}
+
+          {/* Create Form */}
+          <form onSubmit={handleCreate} className="bg-gray-700 p-4 rounded-lg space-y-4">
+            <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wider">Create New Alert</h3>
+            
+            <div className="flex space-x-4">
+              <div className="flex-1">
+                <label className="block text-xs text-gray-400 mb-1">Webhook URL</label>
+                <input 
+                  type="url" 
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
+                  placeholder="https://hooks.slack.com/..."
+                  className="w-full bg-gray-900 text-white border border-gray-600 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+                  required
+                />
+              </div>
+              
+              <div className="w-1/3">
+                <label className="block text-xs text-gray-400 mb-1">Provider</label>
+                <select 
+                  value={provider}
+                  onChange={(e) => setProvider(e.target.value as any)}
+                  className="w-full bg-gray-900 text-white border border-gray-600 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+                >
+                  <option value="discord">Discord</option>
+                  <option value="slack">Slack</option>
+                  <option value="generic">Generic JSON</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="flex space-x-4">
+              <div className="flex-1">
+                <label className="block text-xs text-gray-400 mb-1">Target Countries (comma-separated ISO codes)</label>
+                <input 
+                  type="text" 
+                  value={countriesInput}
+                  onChange={(e) => setCountriesInput(e.target.value)}
+                  placeholder="e.g. US, UA, RU (Leave empty for all)"
+                  className="w-full bg-gray-900 text-white border border-gray-600 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+                />
+              </div>
+            </div>
+
+            <button 
+              type="submit" 
+              className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded transition-colors text-sm"
+            >
+              Add Alert
+            </button>
+          </form>
+
+          {/* List Webhooks */}
+          <div>
+            <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wider mb-3">Active Alerts</h3>
+            
+            {loading ? (
+              <div className="text-gray-400 text-sm text-center py-4">Loading...</div>
+            ) : webhooks.length === 0 ? (
+              <div className="text-gray-500 text-sm text-center py-4 bg-gray-700 rounded-lg">No webhooks configured.</div>
+            ) : (
+              <div className="space-y-3">
+                {webhooks.map((wh) => (
+                  <div key={wh.id} className="bg-gray-700 border border-gray-600 p-4 rounded-lg flex items-center justify-between">
+                    <div className="flex-1 overflow-hidden pr-4">
+                      <div className="flex items-center space-x-2 mb-1">
+                        <span className="text-xs uppercase bg-gray-800 text-gray-300 px-2 py-0.5 rounded font-mono">
+                          {wh.provider}
+                        </span>
+                        {wh.countries && (
+                          <span className="text-xs uppercase bg-blue-900 bg-opacity-30 text-blue-400 px-2 py-0.5 rounded font-mono border border-blue-800">
+                            🌍 {wh.countries.join(', ')}
+                          </span>
+                        )}
+                        <span className={`text-xs px-2 py-0.5 rounded ${wh.is_active ? 'bg-green-900 text-green-400' : 'bg-red-900 text-red-400'}`}>
+                          {wh.is_active ? 'Active' : 'Inactive'}
+                        </span>
+                      </div>
+                      <div className="text-gray-300 text-sm truncate opacity-70" title={wh.url}>
+                        {wh.url}
+                      </div>
+                    </div>
+                    <div className="flex space-x-2">
+                      <button 
+                        onClick={() => handleTest(wh.id)}
+                        className="text-xs bg-gray-600 hover:bg-gray-500 text-white px-3 py-1.5 rounded transition-colors"
+                        title="Send Test Event"
+                      >
+                        Test
+                      </button>
+                      <button 
+                        onClick={() => handleToggleActive(wh)}
+                        className="text-xs bg-gray-600 hover:bg-gray-500 text-white px-3 py-1.5 rounded transition-colors"
+                      >
+                        {wh.is_active ? 'Disable' : 'Enable'}
+                      </button>
+                      <button 
+                        onClick={() => handleDelete(wh.id)}
+                        className="text-xs bg-red-600 hover:bg-red-500 text-white px-3 py-1.5 rounded transition-colors"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
-import { Shield, RefreshCw, AlertTriangle, Layers } from 'lucide-react';
+import { Shield, RefreshCw, AlertTriangle, Layers, Bell } from 'lucide-react';
 import { processPendingPosts } from '../api/client';
 import type { ProcessPendingResponse, EventGlobalMetrics } from '../types';
+import { AlertsModal } from './AlertsModal';
 
 interface HeaderProps {
   isOnline: boolean;
@@ -16,6 +17,7 @@ export const Header: React.FC<HeaderProps> = ({
 }) => {
   const [isProcessing, setIsProcessing] = useState(false);
   const [processResult, setProcessResult] = useState<ProcessPendingResponse | null>(null);
+  const [isAlertsModalOpen, setIsAlertsModalOpen] = useState(false);
 
   const handleProcessPending = async () => {
     setIsProcessing(true);
@@ -82,6 +84,14 @@ export const Header: React.FC<HeaderProps> = ({
       {/* Actions */}
       <div className="flex items-center gap-3">
         <button
+          onClick={() => setIsAlertsModalOpen(true)}
+          className="flex items-center gap-2 px-4 py-2 bg-slate-800 hover:bg-slate-700 text-slate-300 font-medium text-xs rounded-lg border border-slate-700 transition-all cursor-pointer"
+        >
+          <Bell className="w-3.5 h-3.5" />
+          <span>Alerts</span>
+        </button>
+
+        <button
           onClick={handleProcessPending}
           disabled={isProcessing}
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-800 disabled:text-slate-500 text-white font-medium text-xs rounded-lg border border-blue-500/50 transition-all shadow-lg shadow-blue-950/50 cursor-pointer"
@@ -96,6 +106,11 @@ export const Header: React.FC<HeaderProps> = ({
           </div>
         )}
       </div>
+
+      <AlertsModal
+        isOpen={isAlertsModalOpen}
+        onClose={() => setIsAlertsModalOpen(false)}
+      />
     </header>
   );
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -103,3 +103,18 @@ export interface EventFilters {
   bbox?: string;
   countries?: string[];
 }
+
+export interface WebhookAlert {
+  id: string;
+  url: string;
+  provider: 'discord' | 'slack' | 'generic';
+  is_active: boolean;
+  min_threat_level: 'High' | 'Critical';
+  countries?: string[];
+  bbox?: [[number, number], [number, number]];
+  created_at: string;
+  updated_at: string;
+}
+
+export type WebhookAlertCreate = Omit<WebhookAlert, 'id' | 'created_at' | 'updated_at'>;
+export type WebhookAlertUpdate = Partial<WebhookAlertCreate>;


### PR DESCRIPTION
## Summary

- Add analyst-configurable Discord, Slack, and generic webhook alerts.
- Trigger alerts for newly-created High/Critical severity events.
- Support country and geographic bounding-box geofencing.
- Add webhook CRUD and connectivity test APIs.
- Add strict SSRF protection with DNS-resolution IP pinning.
- Disable redirects and restrict webhook destinations to HTTP/HTTPS ports 80/443.
- Dispatch webhook notifications asynchronously without blocking intelligence processing.
- Prevent duplicate alerts for merged events.
- Add frontend Alerts management UI.
- Add comprehensive webhook security, geofence, delivery, API, and pipeline tests.

## Security

- Reject localhost, loopback, private, link-local, multicast, unspecified, and cloud metadata addresses.
- Validate every resolved DNS address.
- Pin outbound TCP connections to the validated IP.
- Preserve hostname-based TLS/SNI behavior.
- Reject embedded credentials and unsupported ports.
- Disable HTTP redirects.
- Enforce a strict 3-second request timeout.

## Validation

- Full backend test suite passes: 93 tests.
- Webhook-specific security and behavior tests pass.
- Frontend production build passes.
- `git diff --check` passes.
- Webhook delivery failures cannot break intelligence processing.
- Newly-created events trigger alerts; merged events do not.
- Country and bounding-box geofencing behave correctly.
- No changes to GlobeViewer, FilterPanel, ingestion worker, NLP, or unrelated features.

Fixes #20
