### PR TITLE
Feat #18: add temporal playback scrubber

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { Header } from './components/Header';
 import { FilterPanel } from './components/FilterPanel';
 import { GlobeViewer } from './components/GlobeViewer';
 import { EventDetailDrawer } from './components/EventDetailDrawer';
+import { PlaybackSlider } from './components/PlaybackSlider';
 import { checkHealth, fetchEvents, fetchGlobalMetrics } from './api/client';
 import { wsService } from './api/websocket';
 import type { Event, EventFilters, EventGlobalMetrics } from './types';
@@ -11,8 +12,10 @@ import { AlertCircle, RefreshCw, Zap, X } from 'lucide-react';
 export const App: React.FC = () => {
   const [isOnline, setIsOnline] = useState<boolean>(true);
   const [filters, setFilters] = useState<EventFilters>({});
-  const [events, setEvents] = useState<Event[]>([]);
+  const [events, setEvents] = useState<Event[]>([]); // Normal dashboard events (default limit)
+  const [playbackEvents, setPlaybackEvents] = useState<Event[]>([]); // Bounded large dataset for playback
   const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
+  const [playbackTime, setPlaybackTime] = useState<number | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [liveToast, setLiveToast] = useState<{ message: string; threatLevel: string } | null>(null);
@@ -22,6 +25,21 @@ export const App: React.FC = () => {
     medium: 0,
     low: 0,
   });
+
+  // Derived visible events based on temporal playback
+  const visibleEvents = useMemo(() => {
+    if (playbackTime === null) return events;
+    return playbackEvents.filter(e => new Date(e.event_timestamp).getTime() <= playbackTime);
+  }, [events, playbackEvents, playbackTime]);
+
+  // When selected event becomes hidden by playback, clear selection
+  useEffect(() => {
+    if (selectedEvent && playbackTime !== null) {
+      if (new Date(selectedEvent.event_timestamp).getTime() > playbackTime) {
+        setSelectedEvent(null);
+      }
+    }
+  }, [playbackTime, selectedEvent]);
 
   // Load global metrics from API
   const loadMetrics = useCallback(async () => {
@@ -41,8 +59,13 @@ export const App: React.FC = () => {
       const healthy = await checkHealth();
       setIsOnline(healthy);
 
+      // Fetch normal dashboard events
       const res = await fetchEvents(filters);
       setEvents(res.items);
+
+      // Fetch a bounded large dataset for complete historical playback (Issue #18)
+      const playbackRes = await fetchEvents(filters, 10000);
+      setPlaybackEvents(playbackRes.items);
     } catch (err: any) {
       console.error('Failed to load events:', err);
       setIsOnline(false);
@@ -112,7 +135,7 @@ export const App: React.FC = () => {
         <FilterPanel
           filters={filters}
           onFilterChange={setFilters}
-          events={events}
+          events={playbackTime === null ? events : visibleEvents.slice(0, 100)}
           selectedEvent={selectedEvent}
           onSelectEvent={setSelectedEvent}
           globalMetrics={globalMetrics}
@@ -157,9 +180,15 @@ export const App: React.FC = () => {
 
           {/* Cesium Globe */}
           <GlobeViewer
-            events={events}
+            events={visibleEvents}
             selectedEvent={selectedEvent}
             onSelectEvent={setSelectedEvent}
+          />
+          {/* Temporal Playback Slider */}
+          <PlaybackSlider
+            events={playbackEvents} // Pass full filtered dataset to calculate range
+            playbackTime={playbackTime}
+            setPlaybackTime={setPlaybackTime}
           />
         </main>
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -18,8 +18,8 @@ export const apiClient = axios.create({
   },
 });
 
-export const fetchEvents = async (filters: EventFilters = {}): Promise<EventListResponse> => {
-  const params: Record<string, any> = { limit: 100 };
+export const fetchEvents = async (filters: EventFilters = {}, limit?: number): Promise<EventListResponse> => {
+  const params: Record<string, any> = { limit: limit ?? (filters as any).limit ?? 100 };
   if (filters.threat_level) params.threat_level = filters.threat_level;
   if (filters.min_threat_score) params.min_threat_score = filters.min_threat_score;
   if (filters.search) params.search = filters.search;

--- a/frontend/src/components/PlaybackSlider.tsx
+++ b/frontend/src/components/PlaybackSlider.tsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useState, useMemo, useRef } from 'react';
+import { Play, Pause, RotateCcw, Clock } from 'lucide-react';
+import type { Event } from '../types';
+
+interface PlaybackSliderProps {
+  events: Event[];
+  playbackTime: number | null;
+  setPlaybackTime: React.Dispatch<React.SetStateAction<number | null>>;
+}
+
+export const PlaybackSlider: React.FC<PlaybackSliderProps> = ({ events, playbackTime, setPlaybackTime }) => {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const playIntervalRef = useRef<number | null>(null);
+
+  // Calculate timeline range
+  const { minTime, maxTime } = useMemo(() => {
+    if (events.length === 0) return { minTime: 0, maxTime: 0 };
+    const times = events.map((e) => new Date(e.event_timestamp).getTime());
+    return {
+      minTime: Math.min(...times),
+      maxTime: Math.max(...times),
+    };
+  }, [events]);
+
+  const hasRange = minTime < maxTime;
+  const isDisabled = events.length === 0;
+
+  // Cleanup on unmount or when pausing
+  useEffect(() => {
+    if (!isPlaying && playIntervalRef.current) {
+      window.clearInterval(playIntervalRef.current);
+      playIntervalRef.current = null;
+    }
+    return () => {
+      if (playIntervalRef.current) {
+        window.clearInterval(playIntervalRef.current);
+        playIntervalRef.current = null;
+      }
+    };
+  }, [isPlaying]);
+
+  // Playback timer tick
+  useEffect(() => {
+    if (isPlaying && hasRange) {
+      playIntervalRef.current = window.setInterval(() => {
+        setPlaybackTime((prevTime) => {
+          let current = prevTime;
+          if (current === null) {
+            current = minTime;
+          }
+
+          // Calculate step size (e.g., traverse the whole range in 10 seconds at 100ms ticks = 100 steps)
+          // Steps: duration = 10000ms. interval = 100ms. steps = 100.
+          const range = maxTime - minTime;
+          const stepSize = Math.max(range / 100, 1000); // minimum step size 1 second
+
+          let next = current + stepSize;
+          if (next >= maxTime) {
+            next = maxTime;
+            setIsPlaying(false);
+          }
+          return next;
+        });
+      }, 100);
+    }
+
+    // Proper cleanup of interval to prevent duplicates when dependencies change
+    return () => {
+      if (playIntervalRef.current) {
+        window.clearInterval(playIntervalRef.current);
+        playIntervalRef.current = null;
+      }
+    };
+  }, [isPlaying, hasRange, minTime, maxTime, setPlaybackTime]);
+
+  const handlePlayPause = () => {
+    if (isDisabled) return;
+
+    if (!isPlaying) {
+      // If we are at the end (or don't have a time), reset to start before playing
+      if (playbackTime === null || playbackTime >= maxTime) {
+        setPlaybackTime(minTime);
+      }
+      setIsPlaying(true);
+    } else {
+      setIsPlaying(false);
+    }
+  };
+
+  const handleReset = () => {
+    setIsPlaying(false);
+    setPlaybackTime(null);
+  };
+
+  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (isDisabled) return;
+    setIsPlaying(false);
+    const value = parseInt(e.target.value, 10);
+    setPlaybackTime(value >= maxTime ? null : value);
+  };
+
+  if (isDisabled) {
+    return null; // Don't show if no events to scrub
+  }
+
+  const currentDisplayTime = playbackTime !== null ? playbackTime : maxTime;
+
+  return (
+    <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-40 bg-slate-950/90 border border-slate-800 text-slate-200 px-6 py-4 rounded-2xl shadow-2xl backdrop-blur-md flex flex-col gap-3 min-w-[500px]">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Clock className="w-4 h-4 text-blue-400" />
+          <h3 className="text-xs font-mono font-bold uppercase tracking-wider text-slate-300">
+            Temporal Playback
+          </h3>
+        </div>
+        <div className="text-xs font-mono text-blue-300 font-bold bg-blue-950/50 px-2 py-1 rounded">
+          {new Date(currentDisplayTime).toLocaleString()}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            onClick={handlePlayPause}
+            disabled={isDisabled || !hasRange}
+            className={`p-2 rounded-lg border transition-all ${
+              isPlaying
+                ? 'bg-amber-900/50 border-amber-800 text-amber-400 hover:bg-amber-900/70'
+                : 'bg-blue-900/50 border-blue-800 text-blue-400 hover:bg-blue-900/70'
+            } disabled:opacity-50 disabled:cursor-not-allowed`}
+            title={isPlaying ? 'Pause' : 'Play'}
+          >
+            {isPlaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
+          </button>
+
+          <button
+            onClick={handleReset}
+            disabled={isDisabled || playbackTime === null}
+            className="p-2 rounded-lg border border-slate-700 bg-slate-800/50 text-slate-400 hover:bg-slate-800 hover:text-slate-200 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            title="Reset"
+          >
+            <RotateCcw className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 flex items-center gap-3">
+          <span className="text-[10px] font-mono text-slate-500 shrink-0">
+            {new Date(minTime).toLocaleDateString()}
+          </span>
+          <input
+            type="range"
+            min={minTime}
+            max={maxTime}
+            value={currentDisplayTime}
+            onChange={handleSliderChange}
+            disabled={isDisabled || !hasRange}
+            className="flex-1 h-1.5 bg-slate-800 rounded-lg appearance-none cursor-pointer accent-blue-500 focus:outline-none"
+          />
+          <span className="text-[10px] font-mono text-slate-500 shrink-0">
+            {new Date(maxTime).toLocaleDateString()}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

- Add a chronological temporal playback scrubber for threat events.
- Allow analysts to scrub through historical events on the globe.
- Add play, pause, reset, and automatic end-of-range behavior.
- Preserve all existing event filters during playback.
- Fetch a separate bounded historical playback dataset of up to 10,000 events.
- Keep normal dashboard pagination unchanged.
- Filter playback events entirely client-side without repeated API requests.
- Automatically clear selected events that move into the future during rewind.
- Add safe interval cleanup to prevent duplicate playback timers.
- Preserve the existing Cesium GlobeViewer implementation unchanged.

## Validation

- Full backend test suite passes: 83 tests.
- Frontend production build passes.
- `git diff --check` passes.
- Playback scrubbing performs no network requests.
- Playback uses a bounded historical dataset.
- Normal dashboard pagination remains unchanged.
- Timer cleanup prevents duplicate intervals.
- Empty, single-event, and identical-timestamp datasets are handled safely.
- Existing real-time event behavior remains intact.
- GlobeViewer and backend code were not modified.

Fixes #18